### PR TITLE
fix: Fix Invalid Firebase Ids

### DIFF
--- a/front-end/src/Manage.tsx
+++ b/front-end/src/Manage.tsx
@@ -65,11 +65,11 @@ const Manage: React.FunctionComponent<ManageProps> = ({
             onClick={() => {
               window.location.href = `${
                 window.location.href
-              }?dealership=${encodeURI(dealerName)}`;
+              }?dealership=${encodeURI(dealerName.replace(/ /g, ""))}`;
             }}
           >
             {"https://carshowroomar.web.app?dealership=" +
-              encodeURI(dealerName)}
+              encodeURI(dealerName.replace(/ /g, ""))}
           </Typography>
         </Toolbar>
       </AppBar>

--- a/front-end/src/Scripts/firebaseCreateDealership.ts
+++ b/front-end/src/Scripts/firebaseCreateDealership.ts
@@ -10,7 +10,7 @@ export const createDealership = (
   return firebaseApp
     .firestore()
     .collection("dealerships")
-    .doc(encodeURI(name))
+    .doc(encodeURI(name.replace(/ /g, "")))
     .set({ name, address, email, phone, password, cars: [] })
     .then(() => true)
     .catch((err) => {

--- a/front-end/src/Scripts/firebaseGetCars.ts
+++ b/front-end/src/Scripts/firebaseGetCars.ts
@@ -4,7 +4,7 @@ export const getCars = (name: string) => {
   return firebaseApp
     .firestore()
     .collection("dealerships")
-    .doc(encodeURI(name))
+    .doc(encodeURI(name.replace(/ /g, "")))
     .get()
     .then((value) => {
       const data = value.data();

--- a/front-end/src/Scripts/firebaseUpdateCars.ts
+++ b/front-end/src/Scripts/firebaseUpdateCars.ts
@@ -4,7 +4,7 @@ export const updateCars = (name: string, cars: any) => {
   return firebaseApp
     .firestore()
     .collection("dealerships")
-    .doc(encodeURI(name))
+    .doc(encodeURI(name.replace(/ /g, "")))
     .update({ cars })
     .then(() => true)
     .catch((err) => {


### PR DESCRIPTION
Now remove all spaces instead of encoding as %20, as Firestore does not like the `%` character.